### PR TITLE
Fix bug in disconnecting

### DIFF
--- a/src/client/NetworkingClient.hpp
+++ b/src/client/NetworkingClient.hpp
@@ -2,6 +2,7 @@
 #define NetworkingClient_hpp
 
 #include <stdio.h>
+#include <atomic>
 #include <SFML/Network.hpp>
 #include "../common/game_def.hpp"
 
@@ -27,7 +28,7 @@ class NetworkingClient {
     sf::UdpSocket* create_realtime_client()
     {
         sf::UdpSocket* realtime_client = new sf::UdpSocket;
-        realtime_client->bind(4846);
+        realtime_client->bind(0);
         return realtime_client;
     }
 

--- a/src/server/NetworkingServer.cpp
+++ b/src/server/NetworkingServer.cpp
@@ -164,11 +164,13 @@ void NetworkingServer::ApiServer() {
                                 break;
                             case sf::TcpSocket::Error:
                                 std::cout << "TCP client encountered error. Removing client." << std::endl;
+                                 selector.remove(client);
                                 DeleteClient(&client, selector);
                                 break;
                             case sf::TcpSocket::Disconnected:
                                 // clean up mClientMoves/mClientPositions hashes
                                 std::cout << "TCP client disconnected. Removing client. " << std::endl;
+                                selector.remove(client);
                                 DeleteClient(&client, selector);
                                 break;
                             default:
@@ -185,10 +187,9 @@ void NetworkingServer::ApiServer() {
 void NetworkingServer::DeleteClient(sf::TcpSocket* client, sf::SocketSelector selector) {
     mClientInputsWriteLock.lock();
 
-    mClientMoves.erase(mClientSocketsToIds[client]);
-    selector.remove(*client);
-    mClientSocketsToIds.erase(client);
     delete client;
+    mClientMoves.erase(mClientSocketsToIds[client]);
+    mClientSocketsToIds.erase(client);
 
     mClientInputsWriteLock.unlock();
 }


### PR DESCRIPTION
Disconnecting wouldn't remove from the selector, but it would free the
socket. For whatever reason this meant after a client disconnected
another wouldn't be able to connect.

I also fixed a compilation error when building on Linux - an include was
missing for the atomic std lib. Not sure why it didn't trigger on OS X.

ALSO following bad commit message hygiene, but there was a bug where I
couldn't run multiple clients at the same time because they were all
binding to the same port 4846. I bind to 0 now which selects any
available port.