### PR TITLE
Improve the way players are refreshed on client connect/disconnect

### DIFF
--- a/src/common/ThreadSafeVector.hpp
+++ b/src/common/ThreadSafeVector.hpp
@@ -38,6 +38,9 @@ class ThreadSafeVector {
             std::copy(mVector.begin(), mVector.end(), std::back_inserter(vector_copy));
             return vector_copy;
         }
+        void forceClear() {
+            mVector.clear();
+        }
 
     private:
         std::vector<T> mVector;

--- a/src/common/game_def.hpp
+++ b/src/common/game_def.hpp
@@ -52,7 +52,8 @@ struct direction {
 };
 
 struct client_inputs {
-    std::vector<int> client_ids;
+    std::vector<int> new_client_ids;
+    std::vector<int> removed_client_ids;
     std::vector<client_direction_update> client_direction_updates;
     std::vector<client_groupability_update> client_groupability_updates;
 };

--- a/src/server/GameController.hpp
+++ b/src/server/GameController.hpp
@@ -27,21 +27,13 @@ class GameController {
      void loadLevel(size_t max_player_count, size_t max_mine_count);
 
      client_inputs collectInputs();
-     void computeGameState(
-         const std::vector<int>& client_ids,
-         const std::vector<client_direction_update>& client_direction_updates,
-         const std::vector<client_groupability_update>& client_groupability_updates);
-     void refreshPlayers(std::vector<int> client_ids);
-     void updatePlayers(std::vector<client_direction_update> client_direction_updates,
-          std::vector<client_groupability_update> client_groupability_updates);
+     void computeGameState(const client_inputs& cis);
+     void updatePlayers(const client_inputs& cis);
      void refreshAndUpdateGroups();
      void setNetworkState();
      void incrementTick();
 
-     void updateGameObjects(
-         const std::vector<int>& client_ids,
-         const std::vector<client_direction_update>& client_direction_updates,
-         const std::vector<client_groupability_update>& client_groupability_updates);
+     void updateGameObjects(const client_inputs& cis);
      void updateGameObjectsPostPhysics();
 
      void updateGroups();

--- a/src/server/LevelController.cpp
+++ b/src/server/LevelController.cpp
@@ -78,6 +78,10 @@ std::vector<int> LevelController::getPlayerIds() {
     return player_ids;
 }
 
+std::shared_ptr<Player> LevelController::getPlayer(int player_id) {
+    return mPlayers[player_id];
+}
+
 std::vector<std::shared_ptr<Player>> LevelController::getPlayers() {
     return mPlayers;
 }
@@ -88,6 +92,14 @@ std::vector<std::shared_ptr<Group>> LevelController::getGroups() {
 
 std::vector<std::shared_ptr<Mine>> LevelController::getMines() {
     return mMines;
+}
+
+std::vector<std::shared_ptr<Player>> LevelController::getActivePlayers() {
+    std::vector<std::shared_ptr<Player>> active_players;
+    std::copy_if(
+        mPlayers.begin(), mPlayers.end(), std::back_inserter(active_players),
+        [](std::shared_ptr<Player> player){return player->isActive();});
+    return active_players;
 }
 
 std::vector<std::shared_ptr<Group>> LevelController::getActiveGroups() {

--- a/src/server/LevelController.hpp
+++ b/src/server/LevelController.hpp
@@ -23,10 +23,13 @@ class LevelController {
 
      std::vector<int> getPlayerIds();
 
+     std::shared_ptr<Player> getPlayer(int player_id);
+
      std::vector<std::shared_ptr<Player>> getPlayers();
      std::vector<std::shared_ptr<Group>> getGroups();
      std::vector<std::shared_ptr<Mine>> getMines();
 
+     std::vector<std::shared_ptr<Player>> getActivePlayers();
      std::vector<std::shared_ptr<Group>> getActiveGroups();
      std::vector<std::shared_ptr<Mine>> getActiveMines();
 

--- a/src/server/NetworkingServer.hpp
+++ b/src/server/NetworkingServer.hpp
@@ -31,9 +31,6 @@ class NetworkingServer {
         std::vector<std::shared_ptr<Group>> active_groups,
         std::vector<std::shared_ptr<Mine>> active_mines);
      void incrementTick();
-     std::vector<client_direction_update> getClientDirectionUpdates();
-     std::vector<client_groupability_update> getClientGroupabilityUpdates();
-     std::vector<int> getClientIds();
 
  private:
      void realtimeServer();
@@ -55,7 +52,15 @@ class NetworkingServer {
         sf::IpAddress& sender,
         unsigned short port);
 
+     std::vector<client_direction_update> getClientDirectionUpdates();
+     std::vector<client_groupability_update> getClientGroupabilityUpdates();
+     std::vector<int> getClientIds();
+     std::vector<int> popNewClientIds();
+     std::vector<int> popRemovedClientIds();
+
      ThreadSafeMap<sf::TcpSocket*, sf::Int32> mClientSocketsToIds;
+     ThreadSafeVector<int> mNewClientIds;
+     ThreadSafeVector<int> mRemovedClientIds;
      ThreadSafeVector<GroupUpdate> mGroupUpdates;
      ThreadSafeVector<MineUpdate> mMineUpdates;
      ThreadSafeMap<sf::Uint32, sf::Vector2f> mClientMoves;


### PR DESCRIPTION
We used to have a function called `refreshPlayers` which would infer which client_ids were added/removed. This is inefficient and complicated. Instead `NetworkingServer` now communicates the new/removed client ids and players are updated accordingly in `updatePlayers`