### PR TITLE
Networking thread improvements

### DIFF
--- a/src/client/systems/ClientGameController.cpp
+++ b/src/client/systems/ClientGameController.cpp
@@ -86,6 +86,7 @@ void ClientGameController::handleEvents(sf::Event& event) {
 void ClientGameController::update() {
     fetchPlayerId();
     setClientUpdates();
+
     if (mNetworkingClient->getGameStateIsFresh()) {
         rewindAndReplay();
         GameController::update();
@@ -97,10 +98,10 @@ void ClientGameController::update() {
 void ClientGameController::rewindAndReplay() {
     // Rewind
     GameState game_state = mNetworkingClient->getGameState();
-    int tick_delta = getTick() - game_state.tick;
     applyGameState(game_state);
 
     // Replay
+    int tick_delta = getTick() - game_state.tick;
     if (tick_delta <= 0) {return;}  // If the client is behind the server we don't need to replay
 
     // Loop through ticks that need to be replayed and apply client input from cache if present
@@ -108,13 +109,13 @@ void ClientGameController::rewindAndReplay() {
         ClientInputAndTick client_input_and_tick;
         unsigned int replay_tick = game_state.tick + i;
 
-        if(mTickToInput.count(replay_tick) > 0) {
+        if (mTickToInput.count(replay_tick) > 0) {
             client_input_and_tick = mTickToInput[replay_tick];
             GameController::computeGameState(
                 getClientInputs(client_input_and_tick.cru, client_input_and_tick.cuu),
-                GameController::MIN_TIME_STEP
-            );
+                GameController::MIN_TIME_STEP);
         } else {
+            // If we don't have input for this tick pass in empty ClientInputs
             GameController::computeGameState(ClientInputs(), GameController::MIN_TIME_STEP);
         }
     }

--- a/src/common/util/game_def.hpp
+++ b/src/common/util/game_def.hpp
@@ -19,10 +19,6 @@ struct ReliableCommand {
     sf::Uint32 tick;
 };
 
-struct PlayerId {
-    sf::Uint32 player_id;
-};
-
 enum ReliableCommandType {register_client, player_id, client_reliable_update};
 enum UnreliableCommandType {client_unreliable_update, fetch_state};
 

--- a/src/common/util/game_settings.hpp
+++ b/src/common/util/game_settings.hpp
@@ -1,12 +1,38 @@
+#ifndef game_settings_hpp
+#define game_settings_hpp
+
 #include <SFML/Graphics.hpp>
 
+/* Game Logic */
 const int MAX_PLAYER_COUNT = 10;
 const int MAX_MINE_COUNT = 5;
-const bool USE_SHADER = false; 
+const bool USE_SHADER = false;
 const sf::Vector2f WINDOW_RESOLUTION(800, 600);
 const float MINE_SIZE = 20.f;
 const float GROUP_START_OFFSET_X = 20.f;
-const float GROUP_START_OFFSET_Y = 20.f; 
+const float GROUP_START_OFFSET_Y = 20.f;
 const float MINE_START_OFFSET_X = 50.f;
 const float MINE_START_OFFSET_Y = 100.f;
 
+/* Threads */
+
+const std::chrono::milliseconds SERVER_INPUT_WINDOW_SLEEP(50);
+
+const std::chrono::milliseconds CLIENT_RELIABLE_SEND_SLEEP(16);
+const std::chrono::milliseconds SERVER_RELIABLE_REVC_SEND_SLEEP(
+    (CLIENT_RELIABLE_SEND_SLEEP/MAX_PLAYER_COUNT)/2);
+const std::chrono::milliseconds CLIENT_RELIBALE_RECV_SLEEP(SERVER_RELIABLE_REVC_SEND_SLEEP/2);
+
+const std::chrono::milliseconds CLIENT_UNRELIABLE_SEND_SLEEP(16);
+const std::chrono::milliseconds SERVER_UNRELIABLE_RECV_SLEEP(
+    (CLIENT_UNRELIABLE_SEND_SLEEP/MAX_PLAYER_COUNT)/2);
+
+const std::chrono::milliseconds SERVER_BROADCAST_GAME_STATE_SLEEP(16);
+const std::chrono::milliseconds CLIENT_UNRELIABLE_RECV_SLEEP(SERVER_BROADCAST_GAME_STATE_SLEEP/2);
+
+/* Networking */
+static const char* CLIENT_IP = "127.0.0.1";
+static const unsigned short SERVER_TCP_PORT = 4844;
+static const char* SERVER_IP = "127.0.0.1";
+
+#endif /* game_settings_hpp */

--- a/src/common/util/game_settings.hpp
+++ b/src/common/util/game_settings.hpp
@@ -2,6 +2,7 @@
 #define game_settings_hpp
 
 #include <SFML/Graphics.hpp>
+#include <chrono>
 
 /* Game Logic */
 const int MAX_PLAYER_COUNT = 10;

--- a/src/common/util/network_util.cpp
+++ b/src/common/util/network_util.cpp
@@ -41,17 +41,6 @@ sf::Packet& operator >>(sf::Packet& packet, sf::Vector2f& vector_2f) {
         >> vector_2f.y;
 }
 
-
-sf::Packet& operator <<(sf::Packet& packet, const PlayerId& player_id) {
-    return packet
-        << player_id.player_id;
-}
-
-sf::Packet& operator >>(sf::Packet& packet, PlayerId& player_id) {
-    return packet
-        >> player_id.player_id;
-}
-
 sf::Socket::Status receiveWithTimeout(sf::TcpSocket& socket, sf::Packet& packet, sf::Time timeout) {
     sf::SocketSelector selector;
     selector.add(socket);

--- a/src/common/util/network_util.hpp
+++ b/src/common/util/network_util.hpp
@@ -13,9 +13,6 @@ sf::Packet& operator >>(sf::Packet& packet, ReliableCommand& api_command);
 sf::Packet& operator <<(sf::Packet& packet, const sf::Vector2f& vector_2f);
 sf::Packet& operator >>(sf::Packet& packet, sf::Vector2f& vector_2f);
 
-sf::Packet& operator <<(sf::Packet& packet, const PlayerId& player_id);
-sf::Packet& operator >>(sf::Packet& packet, PlayerId& player_id);
-
 sf::Socket::Status receiveWithTimeout(sf::TcpSocket& socket, sf::Packet& packet, sf::Time timeout);
 
 #endif /* network_util_hpp */


### PR DESCRIPTION
- Add sleeps to threads to limit cpu usage
- Broadcast game state to all clients constantly instead of having
clients ask for it
- Have server and client send udp ports to eachother over the initial
tcp registration communication
- Clean up networking code