### PR TITLE
Unique GameObject ids with storage indexing and type recognition functionality 

### DIFF
--- a/src/client/systems/ClientGameController.cpp
+++ b/src/client/systems/ClientGameController.cpp
@@ -89,10 +89,8 @@ void ClientGameController::update() {
 
     if (mNetworkingClient->getGameStateIsFresh()) {
         rewindAndReplay();
-        GameController::update();
-    } else {
-        GameController::update();  // interpolate
     }
+    GameController::update();
 }
 
 void ClientGameController::rewindAndReplay() {
@@ -126,7 +124,7 @@ void ClientGameController::fetchPlayerId() {
     if (mPlayerId == -1) {
         mPlayerId = mNetworkingClient->getPlayerId();
         if (mPlayerId != -1) {
-            mClientToPlayer[mNetworkingClient->getClientId()] = mPlayerId;
+            mPlayerController->setPlayerClient(mPlayerId, mNetworkingClient->getClientId());
         }
     }
 }

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -16,7 +16,7 @@ add_library(common-lib
     systems/GameController.cpp
     systems/GameObjectStore.cpp
     systems/GroupController.cpp
-    systems/IdController.cpp
+    factories/IdFactory.cpp
 )
 
 target_link_libraries(common-lib PUBLIC sfml-system sfml-graphics sfml-network)

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(common-lib
     systems/GameController.cpp
     systems/GameObjectStore.cpp
     systems/GroupController.cpp
+    systems/PlayerController.cpp
     factories/IdFactory.cpp
 )
 

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(common-lib
     systems/GameController.cpp
     systems/GameObjectStore.cpp
     systems/GroupController.cpp
+    systems/IdController.cpp
 )
 
 target_link_libraries(common-lib PUBLIC sfml-system sfml-graphics sfml-network)

--- a/src/common/factories/IdFactory.cpp
+++ b/src/common/factories/IdFactory.cpp
@@ -1,8 +1,8 @@
-#include "IdController.hpp"
+#include "IdFactory.hpp"
 
 #include <iostream>
 
-uint32_t IdController::getNextId(uint16_t type) {
+uint32_t IdFactory::getNextId(uint16_t type) {
     std::lock_guard<std::mutex> mTypeToIndex_guard(mTypeToIndex_lock);
 
     if (mTypeToIndex_t.count(type) == 0) {
@@ -21,13 +21,13 @@ uint32_t IdController::getNextId(uint16_t type) {
     return (type * OFFSET_VALUE) + index;
 }
 
-size_t IdController::getIndex(uint32_t id) {
+size_t IdFactory::getIndex(uint32_t id) {
     return id % OFFSET_VALUE;
 }
 
-uint16_t IdController::getType(uint32_t id) {
+uint16_t IdFactory::getType(uint32_t id) {
     return id / OFFSET_VALUE;
 }
 
-std::mutex IdController::mTypeToIndex_lock;
-std::unordered_map<uint16_t, size_t> IdController::mTypeToIndex_t;
+std::mutex IdFactory::mTypeToIndex_lock;
+std::unordered_map<uint16_t, size_t> IdFactory::mTypeToIndex_t;

--- a/src/common/factories/IdFactory.hpp
+++ b/src/common/factories/IdFactory.hpp
@@ -1,5 +1,5 @@
-#ifndef IdController_hpp
-#define IdController_hpp
+#ifndef IdFactory_hpp
+#define IdFactory_hpp
 
 #include <unordered_map>
 #include <mutex>
@@ -7,26 +7,26 @@
 
 static const uint32_t OFFSET_VALUE = UINT32_MAX/UINT16_MAX;
 
-class IdController {
+class IdFactory {
  public:
-    static IdController& getInstance() {
-        static IdController instance;
+    static IdFactory& getInstance() {
+        static IdFactory instance;
         return instance;
     }
 
     // Let's make sure we don't accidentally get copies of the singleton.
-    IdController(IdController const&) = delete;
-    void operator=(IdController const&) = delete;
+    IdFactory(IdFactory const&) = delete;
+    void operator=(IdFactory const&) = delete;
 
     uint32_t getNextId(uint16_t type);
     size_t getIndex(uint32_t id);
     uint16_t getType(uint32_t id);
 
  private:
-    IdController() {}
+    IdFactory() {}
 
     static std::mutex mTypeToIndex_lock;
     static std::unordered_map<uint16_t, size_t> mTypeToIndex_t;
 };
 
-#endif /* IdController_hpp */
+#endif /* IdFactory_hpp */

--- a/src/common/objects/CircleGameObject.cpp
+++ b/src/common/objects/CircleGameObject.cpp
@@ -1,10 +1,10 @@
 #include "CircleGameObject.hpp"
 
 
-CircleGameObject::CircleGameObject(unsigned int id, sf::Vector2f position, float radius,
+CircleGameObject::CircleGameObject(uint32_t id, sf::Vector2f position, float radius,
   sf::Color color, std::shared_ptr<PhysicsController> pc):
   GameObject(id), mCircle(std::shared_ptr<Circle>(new Circle(radius, position, color))),
-  mCircleRigidBody(pc->createCRB(radius, position)) {}
+  mCircleRigidBody(pc->createCRB(id, radius, position)) {}
 
 std::shared_ptr<Circle> CircleGameObject::getCircle() {
     return mCircle;

--- a/src/common/objects/CircleGameObject.hpp
+++ b/src/common/objects/CircleGameObject.hpp
@@ -12,7 +12,7 @@
 
 class CircleGameObject : public GameObject {
  public:
-     CircleGameObject(unsigned int id, sf::Vector2f position, float radius, sf::Color color,
+     CircleGameObject(uint32_t id, sf::Vector2f position, float radius, sf::Color color,
         std::shared_ptr<PhysicsController> pc);
      std::shared_ptr<Circle> getCircle();
      void setActive(bool is_active);

--- a/src/common/objects/CircleRigidBody.cpp
+++ b/src/common/objects/CircleRigidBody.cpp
@@ -1,8 +1,8 @@
 #include "CircleRigidBody.hpp"
 
 
-CircleRigidBody::CircleRigidBody(float radius, sf::Vector2f position):
-  mRadius(radius), mPosition(position), mVelocity(0.f, 0.f) {}
+CircleRigidBody::CircleRigidBody(uint32_t id, float radius, sf::Vector2f position):
+  mRadius(radius), mPosition(position), mVelocity(0.f, 0.f), mId(id) {}
 
 
 void CircleRigidBody::setActive(bool is_active) {

--- a/src/common/objects/CircleRigidBody.hpp
+++ b/src/common/objects/CircleRigidBody.hpp
@@ -10,7 +10,7 @@
 
 class CircleRigidBody {
  public:
-    CircleRigidBody(float radius, sf::Vector2f position);
+    CircleRigidBody(uint32_t id, float radius, sf::Vector2f position);
 
     void setActive(bool is_active);
     bool isActive() const;
@@ -29,11 +29,11 @@ class CircleRigidBody {
     void step(sf::Int32 delta_ms);
 
  private:
-   bool mIsActive = false;
-   float mRadius;
-   sf::Vector2f mPosition;
-   sf::Vector2f mVelocity;  // distance/second
-
+    bool mIsActive = false;
+    float mRadius;
+    sf::Vector2f mPosition;
+    sf::Vector2f mVelocity;  // distance/second
+    uint32_t mId;
 };
 
 #endif /* CircleRigidBody_hpp */

--- a/src/common/objects/GameObject.hpp
+++ b/src/common/objects/GameObject.hpp
@@ -5,7 +5,7 @@
 
 class GameObject {
     public:
-        explicit GameObject(int id) {
+        explicit GameObject(uint32_t id) {
             mId = id;
         }
 
@@ -22,7 +22,7 @@ class GameObject {
         }
 
     protected:
-        int mId;
+        uint32_t mId;
         bool mIsActive = false;
 };
 

--- a/src/common/objects/Group.cpp
+++ b/src/common/objects/Group.cpp
@@ -7,8 +7,8 @@
 #include "Group.hpp"
 
 
-Group::Group(int id, sf::Vector2f position, sf::Color color, std::shared_ptr<PhysicsController> pc)
-  :CircleGameObject(id, position, 0.f, color, pc) {}
+Group::Group(uint32_t id, sf::Vector2f position, sf::Color color,
+    std::shared_ptr<PhysicsController> pc):CircleGameObject(id, position, 0.f, color, pc) {}
 
 Group::~Group() {}
 

--- a/src/common/objects/Group.hpp
+++ b/src/common/objects/Group.hpp
@@ -27,7 +27,7 @@ sf::Packet& operator >>(sf::Packet& packet, GroupUpdate& group_update);
 
 class Group : public CircleGameObject {
  public:
-    Group(int id, sf::Vector2f position, sf::Color color, std::shared_ptr<PhysicsController> pc);
+    Group(uint32_t id, sf::Vector2f position, sf::Color color, std::shared_ptr<PhysicsController> pc);
     ~Group();
     Group(const Group& temp_obj) = delete;  // TODO: define this
     Group& operator=(const Group& temp_obj) = delete;  // TODO: define this

--- a/src/common/objects/Mine.cpp
+++ b/src/common/objects/Mine.cpp
@@ -26,7 +26,7 @@ sf::Packet& operator >>(sf::Packet& packet, MineUpdate& mine_update) {
         >> mine_update.radius;
 }
 
-Mine::Mine(unsigned int id, sf::Vector2f position, float size, sf::Color color,
+Mine::Mine(uint32_t id, sf::Vector2f position, float size, sf::Color color,
   std::shared_ptr<PhysicsController> pc):
   CircleGameObject(id, position, size, color, pc) {}
 

--- a/src/common/objects/Mine.hpp
+++ b/src/common/objects/Mine.hpp
@@ -25,7 +25,7 @@ sf::Packet& operator >>(sf::Packet& packet, MineUpdate& mine_update);
 
 class Mine : public CircleGameObject {
  public:
-    Mine(unsigned int id, sf::Vector2f position, float size, sf::Color color,
+    Mine(uint32_t id, sf::Vector2f position, float size, sf::Color color,
        std::shared_ptr<PhysicsController> pc);
     ~Mine();
     Mine(const Mine& temp_obj) = delete;  // TODO: define this

--- a/src/common/objects/Player.cpp
+++ b/src/common/objects/Player.cpp
@@ -22,7 +22,7 @@ sf::Packet& operator >>(sf::Packet& packet, PlayerUpdate& player_update) {
         >> player_update.groupable;
 }
 
-Player::Player(int id):GameObject(id), mDirection(1.0, 1.0), mGroupable(false) {}
+Player::Player(uint32_t id):GameObject(id), mDirection(1.0, 1.0), mGroupable(false) {}
 
 Player::~Player() {}
 

--- a/src/common/objects/Player.hpp
+++ b/src/common/objects/Player.hpp
@@ -20,7 +20,7 @@ sf::Packet& operator >>(sf::Packet& packet, PlayerUpdate& player_update);
 
 class Player: public GameObject {
  public:
-    explicit Player(int id);
+    explicit Player(uint32_t id);
     ~Player();
 
     void setDirection(sf::Vector2f direction);

--- a/src/common/systems/GameController.hpp
+++ b/src/common/systems/GameController.hpp
@@ -13,6 +13,7 @@
 #include "../util/game_state.hpp"
 #include "GameObjectStore.hpp"
 #include "GroupController.hpp"
+#include "PlayerController.hpp"
 
 
 class GameController {
@@ -37,7 +38,7 @@ class GameController {
     void updatePlayers(const ClientInputs& cis);
     void updateGroups();
     void computeGameState(const ClientInputs& cis, sf::Int32 delta_ms);
-    unsigned int createPlayerWithGroup();
+    uint32_t createPlayerWithGroup(uint32_t client_id);
     void applyGameState(GameState game_state);
     GameState getGameState();
     void updateGameObjects(const ClientInputs& cis);
@@ -48,7 +49,7 @@ class GameController {
     std::shared_ptr<PhysicsController> mPhysicsController;
     std::unique_ptr<GameObjectStore> mGameObjectStore;
     std::unique_ptr<GroupController> mGroupController;
-    std::unordered_map<sf::Uint32, int> mClientToPlayer;
+    std::unique_ptr<PlayerController> mPlayerController;
 
     sf::Clock mClock;
     sf::Int32 mElapsedTime = 0;

--- a/src/common/systems/GameObjectStore.hpp
+++ b/src/common/systems/GameObjectStore.hpp
@@ -18,14 +18,9 @@ class GameObjectStore {
 
     void loadLevel(size_t max_player_count, size_t max_mine_count);
 
-    int createPlayer();
-
-    void setPlayerActive(int player_id, bool value);
-    void setMineActive(int mine_id, bool value);
-
-    std::shared_ptr<Player>& getPlayer(int player_id);
-    std::shared_ptr<Group>& getGroup(int group_id);
-    std::shared_ptr<Mine>& getMine(int mine_id);
+    std::shared_ptr<Player>& getPlayer(uint32_t player_id);
+    std::shared_ptr<Group>& getGroup(uint32_t group_id);
+    std::shared_ptr<Mine>& getMine(uint32_t mine_id);
 
     std::vector<std::shared_ptr<Player>>& getPlayers();
     std::vector<std::shared_ptr<Group>>& getGroups();

--- a/src/common/systems/GroupController.cpp
+++ b/src/common/systems/GroupController.cpp
@@ -1,15 +1,22 @@
 #include "GroupController.hpp"
 
 #include <numeric>
+#include <exception>
 #include "../util/game_settings.hpp"
+
 
 GroupController::GroupController(std::vector<std::shared_ptr<Group>>& groups,
     std::vector<std::shared_ptr<Player>>& players): mPlayers(players), mGroups(groups) {}
 
 GroupController::~GroupController() {}
 
-int GroupController::createGroup(int player_id) {
-    int new_group_id = player_id;
+uint32_t GroupController::createGroup(uint32_t player_id) {
+    size_t next_group_index = nextGroupIndex++;
+    if (next_group_index >= mGroups.size()) {
+        throw std::out_of_range("Exceeded max number of groups.");
+    }
+
+    uint32_t new_group_id = mGroups[next_group_index]->getId();
     mGroupToPlayers[new_group_id].push_back(player_id);
     return new_group_id;
 }

--- a/src/common/systems/GroupController.hpp
+++ b/src/common/systems/GroupController.hpp
@@ -8,6 +8,7 @@
 #include "../../common/objects/Player.hpp"
 #include "../../common/objects/Group.hpp"
 
+
 /* Network utilities */
 
 struct GroupIdAndPlayerIds {
@@ -38,7 +39,7 @@ class GroupController {
     GroupController& operator=(const GroupController& temp_obj) = delete;
 
     void update();
-    int createGroup(int player_id);
+    uint32_t createGroup(uint32_t player_id);
     void updatePostPhysics();
     GroupControllerUpdate getUpdate();
     void applyUpdate(GroupControllerUpdate gcu);
@@ -49,7 +50,9 @@ class GroupController {
 
     std::vector<std::shared_ptr<Player>> mPlayers;
     std::vector<std::shared_ptr<Group>> mGroups;
-    std::unordered_map<sf::Uint32, std::vector<sf::Uint32>> mGroupToPlayers;
+    std::unordered_map<uint32_t, std::vector<uint32_t>> mGroupToPlayers;
+
+    size_t nextGroupIndex = 0;
 };
 
 

--- a/src/common/systems/IdController.cpp
+++ b/src/common/systems/IdController.cpp
@@ -1,0 +1,33 @@
+#include "IdController.hpp"
+
+#include <iostream>
+
+uint32_t IdController::getNextId(uint16_t type) {
+    std::lock_guard<std::mutex> mTypeToIndex_guard(mTypeToIndex_lock);
+
+    if (mTypeToIndex_t.count(type) == 0) {
+        mTypeToIndex_t[type] = 0;
+    }
+
+    size_t index = mTypeToIndex_t[type];
+    size_t next_index = index + 1;
+
+    if (next_index >= OFFSET_VALUE) {
+        throw std::runtime_error("Id index surpassed max value.");
+    }
+
+    mTypeToIndex_t[type] = next_index;
+
+    return (type * OFFSET_VALUE) + index;
+}
+
+size_t IdController::getIndex(uint32_t id) {
+    return id % OFFSET_VALUE;
+}
+
+uint16_t IdController::getType(uint32_t id) {
+    return id / OFFSET_VALUE;
+}
+
+std::mutex IdController::mTypeToIndex_lock;
+std::unordered_map<uint16_t, size_t> IdController::mTypeToIndex_t;

--- a/src/common/systems/IdController.hpp
+++ b/src/common/systems/IdController.hpp
@@ -1,0 +1,32 @@
+#ifndef IdController_hpp
+#define IdController_hpp
+
+#include <unordered_map>
+#include <mutex>
+
+
+static const uint32_t OFFSET_VALUE = UINT32_MAX/UINT16_MAX;
+
+class IdController {
+ public:
+    static IdController& getInstance() {
+        static IdController instance;
+        return instance;
+    }
+
+    // Let's make sure we don't accidentally get copies of the singleton.
+    IdController(IdController const&) = delete;
+    void operator=(IdController const&) = delete;
+
+    uint32_t getNextId(uint16_t type);
+    size_t getIndex(uint32_t id);
+    uint16_t getType(uint32_t id);
+
+ private:
+    IdController() {}
+
+    static std::mutex mTypeToIndex_lock;
+    static std::unordered_map<uint16_t, size_t> mTypeToIndex_t;
+};
+
+#endif /* IdController_hpp */

--- a/src/common/systems/PhysicsController.cpp
+++ b/src/common/systems/PhysicsController.cpp
@@ -9,9 +9,10 @@
 
 PhysicsController::PhysicsController() {}
 
-std::shared_ptr<CircleRigidBody> PhysicsController::createCRB(float radius, sf::Vector2f position) {
-    std::shared_ptr<CircleRigidBody> crb = std::shared_ptr<CircleRigidBody>(
-        new CircleRigidBody(radius, position));
+std::shared_ptr<CircleRigidBody> PhysicsController::createCRB(uint32_t id, float radius,
+    sf::Vector2f position) {
+    std::shared_ptr<CircleRigidBody> crb = std::shared_ptr<CircleRigidBody>(new CircleRigidBody(
+        id, radius, position));
     mCircleRigidBodies.push_back(crb);
     return crb;
 }

--- a/src/common/systems/PhysicsController.hpp
+++ b/src/common/systems/PhysicsController.hpp
@@ -12,7 +12,7 @@
 class PhysicsController{
  public:
      PhysicsController();
-     std::shared_ptr<CircleRigidBody> createCRB(float radius, sf::Vector2f position);
+     std::shared_ptr<CircleRigidBody> createCRB(uint32_t id, float radius, sf::Vector2f position);
      void update(sf::Int32 delta_ms);
      void step(sf::Int32 delta_ms);
      void handleCollision();

--- a/src/common/systems/PlayerController.cpp
+++ b/src/common/systems/PlayerController.cpp
@@ -1,0 +1,55 @@
+#include "PlayerController.hpp"
+
+#include <exception>
+#include "../util/game_settings.hpp"
+#include "../factories/IdFactory.hpp"
+
+
+PlayerController::PlayerController(std::vector<std::shared_ptr<Player>>& players)
+    :mPlayers(players) {}
+
+PlayerController::~PlayerController() {}
+
+uint32_t PlayerController::createPlayer(uint32_t client_id) {
+    size_t next_player_index = nextPlayerIndex++;
+    if (next_player_index >= mPlayers.size()) {
+        throw std::out_of_range("Exceeded max number of players.");
+    }
+
+    uint32_t new_player_id = mPlayers[next_player_index]->getId();
+    mClientToPlayer[client_id] = new_player_id;
+    getPlayer(new_player_id)->setActive(true);
+    return new_player_id;
+}
+
+void PlayerController::removePlayer(uint32_t client_id) {
+    getPlayer(mClientToPlayer[client_id])->setActive(false);
+}
+
+void PlayerController::update(const ClientInputs& cis) {
+    uint32_t client_id;
+    for (const auto& client_id_and_unreliable_update : cis.client_id_and_unreliable_updates) {
+        client_id = client_id_and_unreliable_update.client_id;
+        if(mClientToPlayer.count(client_id) > 0) {
+            uint32_t player_id = mClientToPlayer[client_id];
+            getPlayer(player_id)->setDirection(
+                client_id_and_unreliable_update.client_unreliable_update.direction);
+        }
+    }
+    for (const auto& client_id_and_reliable_update : cis.client_id_and_reliable_updates) {
+        client_id = client_id_and_reliable_update.client_id;
+        if(mClientToPlayer.count(client_id) > 0) {
+            uint32_t player_id = mClientToPlayer[client_id];
+            getPlayer(player_id)->setGroupable(
+                client_id_and_reliable_update.client_reliable_update.groupable);
+        }
+    }
+}
+
+void PlayerController::setPlayerClient(uint32_t player_id, uint32_t client_id) {
+    mClientToPlayer[client_id] = player_id;
+}
+
+std::shared_ptr<Player> PlayerController::getPlayer(uint32_t player_id) {
+    return mPlayers[IdFactory::getInstance().getIndex(player_id)];
+}

--- a/src/common/systems/PlayerController.hpp
+++ b/src/common/systems/PlayerController.hpp
@@ -1,0 +1,29 @@
+#ifndef PlayerController_hpp
+#define PlayerController_hpp
+
+#include <vector>
+
+#include "../objects/Player.hpp"
+#include "../util/game_state.hpp"
+
+
+class PlayerController {
+ public:
+    PlayerController(std::vector<std::shared_ptr<Player>>& players);
+    ~PlayerController();
+    PlayerController(const PlayerController& temp_obj) = delete;
+    PlayerController& operator=(const PlayerController& temp_obj) = delete;
+
+    std::shared_ptr<Player> getPlayer(uint32_t player_id);
+    uint32_t createPlayer(uint32_t client_id);
+    void removePlayer(uint32_t client_id);
+    void update(const ClientInputs& cis);
+    void setPlayerClient(uint32_t player_id, uint32_t client_id);
+
+ private:
+    std::vector<std::shared_ptr<Player>> mPlayers;
+    std::unordered_map<uint32_t, uint32_t> mClientToPlayer;
+    size_t nextPlayerIndex = 0;
+};
+
+#endif /* PlayerController_hpp */

--- a/src/common/util/game_def.hpp
+++ b/src/common/util/game_def.hpp
@@ -3,6 +3,7 @@
 
 #include <SFML/Graphics.hpp>
 
+
 struct Keys {
     sf::Keyboard::Key up, down, left, right, group;
 };
@@ -21,5 +22,7 @@ struct ReliableCommand {
 
 enum ReliableCommandType {register_client, player_id, client_reliable_update};
 enum UnreliableCommandType {client_unreliable_update, fetch_state};
+
+enum GameObjectType {player, group, mine};
 
 #endif /* game_def_hpp */

--- a/src/server/systems/ServerGameController.cpp
+++ b/src/server/systems/ServerGameController.cpp
@@ -24,8 +24,8 @@ void ServerGameController::clientConnected(std::shared_ptr<Event> event) {
         case EventType::EVENT_TYPE_CLIENT_CONNECTED: {
             std::shared_ptr<ClientConnectedEvent> client_connect_event = \
                 std::dynamic_pointer_cast<ClientConnectedEvent>(event);
-            int new_client_id = client_connect_event->getClientId();
-            int new_player_id = mClientToPlayer[new_client_id] = createPlayerWithGroup();
+            uint32_t new_client_id = client_connect_event->getClientId();
+            uint32_t new_player_id = createPlayerWithGroup(new_client_id);
             mNetworkingServer->setClientToPlayerId(new_client_id, new_player_id);
             break;
         }
@@ -42,8 +42,8 @@ void ServerGameController::clientDisconnected(std::shared_ptr<Event> event) {
         case EventType::EVENT_TYPE_CLIENT_DISCONNECTED: {
             std::shared_ptr<ClientDisconnectedEvent> client_disconnect_event = \
                 std::dynamic_pointer_cast<ClientDisconnectedEvent>(event);
-            int removed_client_id = client_disconnect_event->getClientId();
-            mGameObjectStore->setPlayerActive(mClientToPlayer[removed_client_id], false);
+            uint32_t removed_client_id = client_disconnect_event->getClientId();
+            mPlayerController->removePlayer(removed_client_id);
             break;
         }
         default: {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,6 +2,7 @@ add_executable(ug-test
     tests-main.cpp
     common/objects/tests-CircleRigidBody.cpp
     common/events/tests-EventController.cpp
+    common/systems/tests-IdController.cpp
     server/systems/tests-ServerGameController.cpp
     client/systems/tests-ClientGameController.cpp
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(ug-test
     tests-main.cpp
     common/objects/tests-CircleRigidBody.cpp
     common/events/tests-EventController.cpp
-    common/systems/tests-IdController.cpp
+    common/factories/tests-IdFactory.cpp
     server/systems/tests-ServerGameController.cpp
     client/systems/tests-ClientGameController.cpp
 )

--- a/tests/common/factories/tests-IdFactory.cpp
+++ b/tests/common/factories/tests-IdFactory.cpp
@@ -1,13 +1,13 @@
 #include <catch.hpp>
-#include "../../../src/common/systems/IdController.hpp"
+#include "../../../src/common/factories/IdFactory.hpp"
 
 
-SCENARIO("Several types of ids used", "[common][systems][IdController]") {
+SCENARIO("Several types of ids used", "[common][systems][IdFactory]") {
     GIVEN("An id of type 0 is fetched") {
         WHEN("An id of type 0 is fetched") {
-            uint32_t first_zero_id = IdController::getInstance().getNextId(0);
-            size_t first_zero_index = IdController::getInstance().getIndex(first_zero_id);
-            uint16_t first_zero_id_type = IdController::getInstance().getType(first_zero_id);
+            uint32_t first_zero_id = IdFactory::getInstance().getNextId(0);
+            size_t first_zero_index = IdFactory::getInstance().getIndex(first_zero_id);
+            uint16_t first_zero_id_type = IdFactory::getInstance().getType(first_zero_id);
             THEN("The first id value, index and type are correct") {
                 REQUIRE(first_zero_id == 0);
                 REQUIRE(first_zero_index == 0);
@@ -15,9 +15,9 @@ SCENARIO("Several types of ids used", "[common][systems][IdController]") {
             }
         }
         WHEN("An id of type 0 is fetched again") {
-            uint32_t second_zero_id = IdController::getInstance().getNextId(0);
-            uint16_t second_zero_id_type = IdController::getInstance().getType(second_zero_id);
-            size_t second_zero_index = IdController::getInstance().getIndex(second_zero_id);
+            uint32_t second_zero_id = IdFactory::getInstance().getNextId(0);
+            uint16_t second_zero_id_type = IdFactory::getInstance().getType(second_zero_id);
+            size_t second_zero_index = IdFactory::getInstance().getIndex(second_zero_id);
             THEN("The second id value, index and type are correct") {
                 REQUIRE(second_zero_id == 1);
                 REQUIRE(second_zero_index == 1);
@@ -25,9 +25,9 @@ SCENARIO("Several types of ids used", "[common][systems][IdController]") {
             }
         }
         WHEN("An id of type 1 is fetched") {
-            uint32_t first_one_id = IdController::getInstance().getNextId(1);
-            size_t first_one_index = IdController::getInstance().getIndex(first_one_id);
-            uint16_t first_one_id_type = IdController::getInstance().getType(first_one_id);
+            uint32_t first_one_id = IdFactory::getInstance().getNextId(1);
+            size_t first_one_index = IdFactory::getInstance().getIndex(first_one_id);
+            uint16_t first_one_id_type = IdFactory::getInstance().getType(first_one_id);
             THEN("The id value, index and type are correct") {
                 REQUIRE(first_one_id == OFFSET_VALUE);
                 REQUIRE(first_one_index == 0);

--- a/tests/common/objects/tests-CircleRigidBody.cpp
+++ b/tests/common/objects/tests-CircleRigidBody.cpp
@@ -2,7 +2,7 @@
 #include "../../../src/common/objects/CircleRigidBody.hpp"
 
 
-SCENARIO( "CircleRigidBody changes position", "[common][objects][CircleRigidBody]" ) {
+SCENARIO("CircleRigidBody changes position", "[common][objects][CircleRigidBody]") {
   sf::Vector2f position = sf::Vector2f(0.f, 0.f);
   CircleRigidBody circle = CircleRigidBody(0.f, position);
 

--- a/tests/common/objects/tests-CircleRigidBody.cpp
+++ b/tests/common/objects/tests-CircleRigidBody.cpp
@@ -4,7 +4,7 @@
 
 SCENARIO("CircleRigidBody changes position", "[common][objects][CircleRigidBody]") {
   sf::Vector2f position = sf::Vector2f(0.f, 0.f);
-  CircleRigidBody circle = CircleRigidBody(0.f, position);
+  CircleRigidBody circle = CircleRigidBody(0, 0.f, position);
 
   GIVEN( "a velocity is set on a circle" ) {
     circle.setVelocity(sf::Vector2f(10.f, 10.f));

--- a/tests/common/systems/tests-IdController.cpp
+++ b/tests/common/systems/tests-IdController.cpp
@@ -1,0 +1,39 @@
+#include <catch.hpp>
+#include "../../../src/common/systems/IdController.hpp"
+
+
+SCENARIO("Several types of ids used", "[common][systems][IdController]") {
+    GIVEN("An id of type 0 is fetched") {
+        WHEN("An id of type 0 is fetched") {
+            uint32_t first_zero_id = IdController::getInstance().getNextId(0);
+            size_t first_zero_index = IdController::getInstance().getIndex(first_zero_id);
+            uint16_t first_zero_id_type = IdController::getInstance().getType(first_zero_id);
+            THEN("The first id value, index and type are correct") {
+                REQUIRE(first_zero_id == 0);
+                REQUIRE(first_zero_index == 0);
+                REQUIRE(first_zero_id_type == 0);
+            }
+        }
+        WHEN("An id of type 0 is fetched again") {
+            uint32_t second_zero_id = IdController::getInstance().getNextId(0);
+            uint16_t second_zero_id_type = IdController::getInstance().getType(second_zero_id);
+            size_t second_zero_index = IdController::getInstance().getIndex(second_zero_id);
+            THEN("The second id value, index and type are correct") {
+                REQUIRE(second_zero_id == 1);
+                REQUIRE(second_zero_index == 1);
+                REQUIRE(second_zero_id_type == 0);
+            }
+        }
+        WHEN("An id of type 1 is fetched") {
+            uint32_t first_one_id = IdController::getInstance().getNextId(1);
+            size_t first_one_index = IdController::getInstance().getIndex(first_one_id);
+            uint16_t first_one_id_type = IdController::getInstance().getType(first_one_id);
+            THEN("The id value, index and type are correct") {
+                REQUIRE(first_one_id == OFFSET_VALUE);
+                REQUIRE(first_one_index == 0);
+                REQUIRE(first_one_id_type == 1);
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
Create IdFactory
- The id system generates ids for "types".
  Types are uint16 number that correspond to game object types.
- The ids are unique among all types.
- Each type has it's own index.
  The index of an id is meant to correspond to a game object's index in the vector it's stored in.
- Given an id you one can retrieve its type.
  This is useful when one has an id and needs to find the corresponding game object.

Use IdFactory
- Replace all GameObject ids with ids fetched from IdFactory
- Assign CircleRigidBodies ids of their parent class
This will be used to determine which game object to fire events for when handling collision
- Create PlayerController
Similar to GameController this updates Player GameObjects